### PR TITLE
Change order of wiki plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import icon from './icon.png'
 
-const order = 1
+const order = 12
 
 const plugin = ({ term, actions, display }) => {
   var search = (searchTerm) => {


### PR DESCRIPTION
As a fallback-plugin, wikipedia shouln't be on top of all results